### PR TITLE
Add Jinja2 template support

### DIFF
--- a/CMake/Jinja2/header.cmake
+++ b/CMake/Jinja2/header.cmake
@@ -12,19 +12,20 @@ function(generate_header_from_jinja2_template  input  output)
 
     # TODO: need to make sure output directory exists
 
-    # message("Using ${MBED_JINJA2_GENERATE_SCRIPT} to generate from ${input} to ${output}")
-
-    # add dependency of the output file on the (merged) yotta config info:
-    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
-                                OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}")
-
-    # add dependency of the output file on the script used to generate it:
-    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
-                                OBJECT_DEPENDS "${MBED_JINJA2_GENERATE_SCRIPT}")
-
-    # add dependency of the output file on the input file:
-    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
-                                OBJECT_DEPENDS "${input}")
+    # add dependency of the output file on:
+    # - the (merged) yotta config info,
+    # - the script used to generate it, and
+    # - the input file.
+    set_source_files_properties(
+        "${output}"
+        PROPERTIES
+            HEADER_FILE_ONLY TRUE
+            GENERATED TRUE
+        OBJECT_DEPENDS
+            "${YOTTA_CONFIG_MERGED_JSON_FILE}" ;
+            "${MBED_JINJA2_GENERATE_SCRIPT}" ;
+            "${input}"
+    )
 
     add_custom_command(
         OUTPUT "${output}"

--- a/CMake/Jinja2/header.cmake
+++ b/CMake/Jinja2/header.cmake
@@ -1,0 +1,45 @@
+# Copyright (C) 2016 ARM Limited. All rights reserved.
+
+if(TARGET_MBED_COMMON_JINJA2_HEADER_TOOLCHAIN_INCLUDED)
+    return()
+endif()
+set(TARGET_MBED_COMMON_JINJA2_HEADER_TOOLCHAIN_INCLUDED 1)
+
+set(MBED_JINJA2_GENERATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../../scripts/jinja2_template.py")
+
+
+function(generate_header_from_jinja2_template  input  output)
+
+    # TODO: need to make sure output directory exists
+
+    # message("Using ${MBED_JINJA2_GENERATE_SCRIPT} to generate from ${input} to ${output}")
+
+    # add dependency of the output file on the (merged) yotta config info:
+    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
+                                OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}")
+
+    # add dependency of the output file on the script used to generate it:
+    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
+                                OBJECT_DEPENDS "${MBED_JINJA2_GENERATE_SCRIPT}")
+
+    # add dependency of the output file on the input file:
+    set_source_files_properties("${output}" PROPERTIES HEADER_FILE_ONLY TRUE
+                                OBJECT_DEPENDS "${input}")
+
+    add_custom_command(
+        OUTPUT "${output}"
+        MAIN_DEPENDENCY "${YOTTA_CONFIG_MERGED_JSON_FILE}"
+        DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${MBED_JINJA2_GENERATE_SCRIPT}"
+        COMMAND python "${MBED_JINJA2_GENERATE_SCRIPT}" "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${output}"
+        COMMENT "Generating ${output}"
+    )
+
+    # first determine a sane name for the generated target:
+    get_filename_component(headerFilename "${output}" NAME)
+    set(generatedName "${PROJECT_NAME}_template_${headerFilename}")
+
+    add_custom_target("${generatedName}" ALL DEPENDS "${input}" "${output}" "${YOTTA_CONFIG_MERGED_JSON_FILE}")
+
+    add_dependencies("${PROJECT_NAME}" "${generatedName}")
+
+endfunction()

--- a/CMake/Jinja2/linker_script.cmake
+++ b/CMake/Jinja2/linker_script.cmake
@@ -1,0 +1,43 @@
+# Copyright (C) 2016 ARM Limited. All rights reserved.
+
+if(TARGET_MBED_COMMON_JINJA2_LINKER_SCRIPT_TOOLCHAIN_INCLUDED)
+    return()
+endif()
+set(TARGET_MBED_COMMON_JINJA2_LINKER_SCRIPT_TOOLCHAIN_INCLUDED 1)
+
+set(MBED_JINJA2_GENERATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../../scripts/jinja2_template.py")
+
+
+function(generate_linker_script_from_jinja2_template  input  output)
+
+    # add dependency of the output file on:
+    # - the (merged) yotta config info,
+    # - the script used to generate it, and
+    # - the input file.
+    set_source_files_properties(
+        "${output}"
+        PROPERTIES
+            GENERATED TRUE
+        OBJECT_DEPENDS
+            "${YOTTA_CONFIG_MERGED_JSON_FILE}" ;
+            "${MBED_JINJA2_GENERATE_SCRIPT}" ;
+            "${input}"
+    )
+
+    add_custom_command(
+        OUTPUT "${output}"
+        MAIN_DEPENDENCY "${YOTTA_CONFIG_MERGED_JSON_FILE}"
+        DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${MBED_JINJA2_GENERATE_SCRIPT}"
+        COMMAND python "${MBED_JINJA2_GENERATE_SCRIPT}" "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${output}"
+        COMMENT "Generating ${output}"
+    )
+
+    # first determine a sane name for the generated target:
+    get_filename_component(linkerScriptFilename "${output}" NAME)
+    set(generatedName "${PROJECT_NAME}_template_${linkerScriptFilename}.cmake")
+
+    add_custom_target("${generatedName}" ALL DEPENDS "${input}" "${output}" "${YOTTA_CONFIG_MERGED_JSON_FILE}")
+
+    add_dependencies("${PROJECT_NAME}" "${generatedName}")
+
+endfunction()

--- a/CMake/Jinja2/source.cmake
+++ b/CMake/Jinja2/source.cmake
@@ -1,0 +1,56 @@
+# Copyright (C) 2016 ARM Limited. All rights reserved.
+
+if(TARGET_MBED_COMMON_JINJA2_TOOLCHAIN_INCLUDED)
+    return()
+endif()
+set(TARGET_MBED_COMMON_JINJA2_TOOLCHAIN_INCLUDED 1)
+
+set(MBED_JINJA2_GENERATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../../scripts/jinja2_template.py")
+
+
+function(generate_source_from_jinja2_template  source  destination)
+
+    # TODO: destination isn't a required argument with this approach, we could pick somewhere in the build directory automatically
+    # TODO: need to make sure output directory exists
+
+    message("using ${MBED_JINJA2_GENERATE_SCRIPT} to generate stuff from ${source} to ${destination}")
+
+    # add dependency of the output file on the (merged) yotta config info:
+    set_source_files_properties(
+        "${destination}" PROPERTIES
+        OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}"
+    )
+
+    # add dependency of the output file on the script used to generate it:
+    set_source_files_properties("${destination}" PROPERTIES
+                                OBJECT_DEPENDS "${MBED_JINJA2_GENERATE_SCRIPT}")
+
+    add_custom_command(
+        OUTPUT "${destination}"
+        MAIN_DEPENDENCY "${YOTTA_CONFIG_MERGED_JSON_FILE}"
+        DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}"
+        COMMAND python "${MBED_JINJA2_GENERATE_SCRIPT}" "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${source}" "${destination}" "${filters}"
+        COMMENT "Generating ${destination}"
+    )
+
+    # to get the generated source file included in the build, we
+    # need to build it into a separate library, and indicate that
+    # the current module's library has a link-dependency on it
+    # (otherwise it would not be linked in the final application):
+
+    # first determine a sane name for the generated library:
+    get_filename_component(sourceFilename "${destination}" NAME)
+    set(generatedLibName "${PROJECT_NAME}_template_${sourceFilename}")
+
+    # generate it:
+    add_library("${generatedLibName}" "${destination}")
+
+    # link the generated library to the existing library for this module:
+    target_link_libraries("${PROJECT_NAME}" "${generatedLibName}")
+
+endfunction()
+
+
+# usage example (note that for yotta, the "source" dir is actually the build dir (this is where the CMakeLists are generated).
+# Use the list dir in a .cmake file in mymodule/source to refer to the mymodule/source directory
+# generate_source_from_jinja2_template("${CMAKE_CURRENT_LIST_DIR}/foo.c.jinja2" "${CMAKE_CURRENT_SOURCE_DIR}/foo.c")

--- a/CMake/Jinja2/source.cmake
+++ b/CMake/Jinja2/source.cmake
@@ -13,19 +13,19 @@ function(generate_source_from_jinja2_template  input  output)
     # TODO: output isn't a required argument with this approach, we could pick somewhere in the build directory automatically
     # TODO: need to make sure output directory exists
 
-    # message("Using ${MBED_JINJA2_GENERATE_SCRIPT} to generate from ${input} to ${output}")
-
-    # add dependency of the output file on the (merged) yotta config info:
-    set_source_files_properties("${output}" PROPERTIES
-                                OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}")
-
-    # add dependency of the output file on the script used to generate it:
-    set_source_files_properties("${output}" PROPERTIES
-                                OBJECT_DEPENDS "${MBED_JINJA2_GENERATE_SCRIPT}")
-
-    # add dependency of the output file on the input file:
-    set_source_files_properties("${output}" PROPERTIES
-                                OBJECT_DEPENDS "${input}")
+    # add dependency of the output file on:
+    # - the (merged) yotta config info,
+    # - the script used to generate it, and
+    # - the input file.
+    set_source_files_properties(
+        "${output}"
+        PROPERTIES
+            GENERATED TRUE
+        OBJECT_DEPENDS
+            "${YOTTA_CONFIG_MERGED_JSON_FILE}" ;
+            "${MBED_JINJA2_GENERATE_SCRIPT}" ;
+            "${input}"
+    )
 
     add_custom_command(
         OUTPUT "${output}"

--- a/CMake/Jinja2/source.cmake
+++ b/CMake/Jinja2/source.cmake
@@ -1,56 +1,53 @@
 # Copyright (C) 2016 ARM Limited. All rights reserved.
 
-if(TARGET_MBED_COMMON_JINJA2_TOOLCHAIN_INCLUDED)
+if(TARGET_MBED_COMMON_JINJA2_SOURCE_TOOLCHAIN_INCLUDED)
     return()
 endif()
-set(TARGET_MBED_COMMON_JINJA2_TOOLCHAIN_INCLUDED 1)
+set(TARGET_MBED_COMMON_JINJA2_SOURCE_TOOLCHAIN_INCLUDED 1)
 
 set(MBED_JINJA2_GENERATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../../scripts/jinja2_template.py")
 
 
-function(generate_source_from_jinja2_template  source  destination)
+function(generate_source_from_jinja2_template  input  output)
 
-    # TODO: destination isn't a required argument with this approach, we could pick somewhere in the build directory automatically
+    # TODO: output isn't a required argument with this approach, we could pick somewhere in the build directory automatically
     # TODO: need to make sure output directory exists
 
-    message("using ${MBED_JINJA2_GENERATE_SCRIPT} to generate stuff from ${source} to ${destination}")
+    # message("Using ${MBED_JINJA2_GENERATE_SCRIPT} to generate from ${input} to ${output}")
 
     # add dependency of the output file on the (merged) yotta config info:
-    set_source_files_properties(
-        "${destination}" PROPERTIES
-        OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}"
-    )
+    set_source_files_properties("${output}" PROPERTIES
+                                OBJECT_DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}")
 
     # add dependency of the output file on the script used to generate it:
-    set_source_files_properties("${destination}" PROPERTIES
+    set_source_files_properties("${output}" PROPERTIES
                                 OBJECT_DEPENDS "${MBED_JINJA2_GENERATE_SCRIPT}")
 
+    # add dependency of the output file on the input file:
+    set_source_files_properties("${output}" PROPERTIES
+                                OBJECT_DEPENDS "${input}")
+
     add_custom_command(
-        OUTPUT "${destination}"
+        OUTPUT "${output}"
         MAIN_DEPENDENCY "${YOTTA_CONFIG_MERGED_JSON_FILE}"
-        DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}"
-        COMMAND python "${MBED_JINJA2_GENERATE_SCRIPT}" "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${source}" "${destination}" "${filters}"
-        COMMENT "Generating ${destination}"
+        DEPENDS "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${MBED_JINJA2_GENERATE_SCRIPT}"
+        COMMAND python "${MBED_JINJA2_GENERATE_SCRIPT}" "${YOTTA_CONFIG_MERGED_JSON_FILE}" "${input}" "${output}"
+        COMMENT "Generating ${output}"
     )
 
-    # to get the generated source file included in the build, we
+    # to get the generated input file included in the build, we
     # need to build it into a separate library, and indicate that
     # the current module's library has a link-dependency on it
     # (otherwise it would not be linked in the final application):
 
     # first determine a sane name for the generated library:
-    get_filename_component(sourceFilename "${destination}" NAME)
+    get_filename_component(sourceFilename "${output}" NAME)
     set(generatedLibName "${PROJECT_NAME}_template_${sourceFilename}")
 
     # generate it:
-    add_library("${generatedLibName}" "${destination}")
+    add_library("${generatedLibName}" "${output}")
 
     # link the generated library to the existing library for this module:
     target_link_libraries("${PROJECT_NAME}" "${generatedLibName}")
 
 endfunction()
-
-
-# usage example (note that for yotta, the "source" dir is actually the build dir (this is where the CMakeLists are generated).
-# Use the list dir in a .cmake file in mymodule/source to refer to the mymodule/source directory
-# generate_source_from_jinja2_template("${CMAKE_CURRENT_LIST_DIR}/foo.c.jinja2" "${CMAKE_CURRENT_SOURCE_DIR}/foo.c")

--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -190,3 +190,4 @@ endif()
 
 include(Jinja2/source)
 include(Jinja2/header)
+include(Jinja2/linker_script)

--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -189,3 +189,4 @@ else()
 endif()
 
 include(Jinja2/source)
+include(Jinja2/header)

--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -188,7 +188,4 @@ else()
     message(FATAL_ERROR "yotta config value mbed.toolchain must be set to either 'armcc' or 'gcc'")
 endif()
 
-
-
-
-
+include(Jinja2/source)

--- a/scripts/jinja2_template.py
+++ b/scripts/jinja2_template.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2016, ARM Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import json
+from jinja2 import Environment, FileSystemLoader
+
+def replace_hyphens_in_keys(dictionary):
+    result = {}
+    # yotta config consists out of nested dictionaries only.
+    for key in dictionary:
+        if isinstance(dictionary[key], dict):
+            # \o/ for recursion
+            value = replace_hyphens_in_keys(dictionary[key])
+        else:
+            value = dictionary[key]
+        # the actual work is done here
+        result[key.replace('-', '_')] = value
+
+    return result
+
+def load_config(configfile):
+    # load and parse the yotta config JSON file
+    with open(configfile, "r") as jsonfile:
+        config = json.load(jsonfile)
+
+    # replace all hyphens in keys with underscores
+    # this is required so that keys can be accessed in a Jinja2 template!
+    # {% set value = config.key %} won't work with a hyphen in the key
+    config = replace_hyphens_in_keys(config)
+
+    return config
+
+
+def render_with_config(source, destination, config):
+    # create the Jinja2 environment
+    env = Environment(loader=FileSystemLoader(os.path.dirname(source)), trim_blocks=True, lstrip_blocks=True)
+
+    # open the template source file
+    template = env.get_template(os.path.basename(source))
+
+    # render the template with the yotta configuration
+    output = template.render(**config)
+
+    # write the generated content to the destination file
+    with open(destination, "w") as outputfile:
+        outputfile.write(output)
+
+
+if __name__ == "__main__":
+    config = load_config(sys.argv[1])
+    render_with_config(sys.argv[2], sys.argv[3], config)

--- a/scripts/jinja2_template.py
+++ b/scripts/jinja2_template.py
@@ -47,7 +47,12 @@ def load_config(configfile):
 
 def render_with_config(config, source, destination):
     # create the Jinja2 environment
-    env = Environment(loader=FileSystemLoader(os.path.dirname(source)), trim_blocks=True, lstrip_blocks=True)
+    env = Environment(
+            loader = FileSystemLoader(os.path.dirname(source)),
+            trim_blocks = True,
+            lstrip_blocks = True,
+            extensions = ['jinja2.ext.do']
+        )
 
     # check if we need to import custom filters
     if os.path.isfile(os.path.join(os.path.dirname(source), 'jinja2_filters.py')):

--- a/scripts/jinja2_template.py
+++ b/scripts/jinja2_template.py
@@ -18,6 +18,9 @@ import sys
 import json
 import jinja2
 
+@jinja2.contextfunction
+def get_context(c):
+    return c
 
 def replace_hyphens_in_keys(dictionary):
     result = {}
@@ -53,6 +56,7 @@ def render_with_config(config, source, destination):
             lstrip_blocks = True,
             extensions = ['jinja2.ext.do']
         )
+    env.globals['context'] = get_context
 
     # check if we need to import custom filters
     if os.path.isfile(os.path.join(os.path.dirname(source), 'jinja2_filters.py')):

--- a/scripts/jinja2_template.py
+++ b/scripts/jinja2_template.py
@@ -16,7 +16,7 @@
 import os
 import sys
 import json
-from jinja2 import Environment, FileSystemLoader
+import jinja2
 
 
 def replace_hyphens_in_keys(dictionary):
@@ -47,8 +47,8 @@ def load_config(configfile):
 
 def render_with_config(config, source, destination):
     # create the Jinja2 environment
-    env = Environment(
-            loader = FileSystemLoader(os.path.dirname(source)),
+    env = jinja2.Environment(
+            loader = jinja2.FileSystemLoader(os.path.dirname(source)),
             trim_blocks = True,
             lstrip_blocks = True,
             extensions = ['jinja2.ext.do']

--- a/target.json
+++ b/target.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "base mbed build target for all mbed OS targets",
   "homepage": "https://github.com/ARMmbed/target-mbed",
   "repository": {


### PR DESCRIPTION
This feature adds CMake functions that setup the correct dependencies for header and source files and then calls a custom python script that generated the targets using the Jinja2 template engine with the entire yotta config as a substitution dictionary.

Functions are available for the following template types: 
- [x] header
- [x] source
- [x] linkerscript

Custom Jinja2 filters can be added to every module by placing a file called `jinja2_filters.py` inside the same folder as the calling cmake file.
This file contains functions, which will be available for use inside the jinja2 template.

This PR is ready for review and merging.

@autopulated @bogdanm @bremoran @0xc0170 @mjs-arm
